### PR TITLE
dont hardcode windows paths for freetype2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ CFLAGS	:=	-g -Wall -O3 -ffunction-sections \
 			-DVERSION_MINOR=${VERSION_MINOR} \
 			-DVERSION_MICRO=${VERSION_MICRO}
 
-CFLAGS	+=	$(INCLUDE) -D__SWITCH__ -IC:\devkitpro/portlibs/switch/include/freetype2
+CFLAGS	+=	$(INCLUDE) -D__SWITCH__ -I$(DEVKITPRO)/portlibs/switch/include/freetype2
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++17
 


### PR DESCRIPTION
This will work on all platforms as long as DEVKITPRO exists in environment variables, and points to the right place.